### PR TITLE
Add model training, saving, and loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,23 @@
 - 胡 (Hu)
 
 有关游戏规则的更多信息，请参阅 [四川麻将](https://zh.wikipedia.org/wiki/四川麻将)。
+
+## 训练模型
+
+要训练模型，请运行以下命令：
+
+```bash
+python train_sichuan_mahjong.py --train
+```
+
+## 保存训练模型
+
+训练完成后，模型将自动保存到指定路径。您可以在 `train_sichuan_mahjong.py` 中设置保存路径。
+
+## 加载训练模型并预测
+
+要加载训练模型并根据手牌和牌桌信息预测出牌，请运行以下命令：
+
+```bash
+python train_sichuan_mahjong.py --predict
+```

--- a/train_sichuan_mahjong.py
+++ b/train_sichuan_mahjong.py
@@ -1,17 +1,56 @@
 import rlcard
 from rlcard.agents import RandomAgent
-from rlcard.utils import set_global_seed, tournament
+from rlcard.utils import set_global_seed, tournament, Logger
+from rlcard.agents.dqn_agent import DQNAgent
+import os
+import argparse
 
-# 创建环境
-env = rlcard.make('sichuan_mahjong')
+def train(env, num_episodes, save_path):
+    # 设置全局种子
+    set_global_seed(0)
 
-# 设置全局种子
-set_global_seed(0)
+    # 设置DQN代理
+    agent = DQNAgent(num_actions=env.num_actions)
+    env.set_agents([agent] + [RandomAgent(num_actions=env.num_actions) for _ in range(env.num_players - 1)])
 
-# 设置代理
-agents = [RandomAgent(num_actions=env.num_actions) for _ in range(env.num_players)]
-env.set_agents(agents)
+    # 训练模型
+    for episode in range(num_episodes):
+        trajectories, _ = env.run(is_training=True)
+        for ts in trajectories[0]:
+            agent.feed(ts)
 
-# 评估性能。与随机代理对战。
-reward = tournament(env, 1000)
-print('随机代理的平均奖励: ', reward)
+        if episode % 100 == 0:
+            print(f'Episode {episode} completed')
+
+    # 保存模型
+    agent.save(save_path)
+    print(f'Model saved to {save_path}')
+
+def predict(env, model_path):
+    # 加载模型
+    agent = DQNAgent(num_actions=env.num_actions)
+    agent.load(model_path)
+    env.set_agents([agent] + [RandomAgent(num_actions=env.num_actions) for _ in range(env.num_players - 1)])
+
+    # 进行预测
+    trajectories, _ = env.run(is_training=False)
+    actions = [ts[1] for ts in trajectories[0]]
+    print('Predicted actions:', actions)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--train', action='store_true', help='Train the model')
+    parser.add_argument('--predict', action='store_true', help='Predict using the trained model')
+    parser.add_argument('--model_path', type=str, default='dqn_model', help='Path to save/load the model')
+    parser.add_argument('--num_episodes', type=int, default=1000, help='Number of episodes for training')
+    args = parser.parse_args()
+
+    # 创建环境
+    env = rlcard.make('sichuan_mahjong')
+
+    if args.train:
+        train(env, args.num_episodes, args.model_path)
+    elif args.predict:
+        predict(env, args.model_path)
+    else:
+        print('Please specify --train or --predict')


### PR DESCRIPTION
Add functionality to train, save, and load a model for predicting actions in Sichuan Mahjong.

* **train_sichuan_mahjong.py**
  - Add code to train a model using a reinforcement learning algorithm.
  - Add code to save the trained model.
  - Add code to load the trained model for prediction.
  - Add command-line argument parsing to specify training or prediction mode.
  - Add logging for training progress and model saving.

* **README.md**
  - Add instructions on how to train the model.
  - Add instructions on how to save the trained model.
  - Add instructions on how to load the trained model for prediction.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/scnon/rlcard-demo/pull/4?shareId=ab83ff29-086a-4b73-ba45-0a5158640305).